### PR TITLE
fix: getting the correct apiName in prod env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/square-connect-plus",
     "description": "Extends the official Square Node.js SDK library with additional functionality",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "author": "Coroliov Oleg",
     "license": "MIT",
     "private": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/square-connect-plus",
     "description": "Extends the official Square Node.js SDK library with additional functionality",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "author": "Coroliov Oleg",
     "license": "MIT",
     "private": false,
@@ -79,6 +79,7 @@
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.5",
         "@types/lodash.camelcase": "^4.3.6",
+        "@types/lodash.capitalize": "^4.2.7",
         "@types/lodash.snakecase": "^4.1.6",
         "@types/mocha": "^9.1.0",
         "@types/node": "^16.11.24",
@@ -113,5 +114,8 @@
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5",
         "uuid": "^8.3.2"
+    },
+    "dependencies": {
+        "lodash.capitalize": "^4.2.1"
     }
 }

--- a/src/interface/ISquareClientConfig.ts
+++ b/src/interface/ISquareClientConfig.ts
@@ -2,8 +2,15 @@ import type { Configuration } from 'square';
 import type { ILogger } from '../logger';
 import type { IRetriesOptions } from './IRetriesOptions';
 
+export type LogContext = {
+    /** square merchant id */
+    merchantId?: string;
+    [key: string]: any;
+};
+
 export interface ISquareClientConfig {
     retry?: Partial<IRetriesOptions>;
     configuration?: Partial<Omit<Configuration, 'accessToken'>>;
     logger?: ILogger;
+    logContext?: LogContext;
 }

--- a/test/unit/client/SquareClient.spec.ts
+++ b/test/unit/client/SquareClient.spec.ts
@@ -42,6 +42,10 @@ describe('SquareClient (unit)', (): void => {
             environment: Environment.Sandbox,
         },
         logger: console,
+        logContext: {
+            someKey: 'someValue',
+            merchantId: 'unknown',
+        },
     };
 
     describe('#constructor', (): void => {
@@ -73,6 +77,9 @@ describe('SquareClient (unit)', (): void => {
                     ...DEFAULT_CONFIGURATION,
                 },
                 logger: undefined,
+                logContext: {
+                    merchantId: 'unknown',
+                },
             });
         });
 

--- a/test/unit/client/SquareClientFactory.spec.ts
+++ b/test/unit/client/SquareClientFactory.spec.ts
@@ -30,6 +30,10 @@ describe('SquareClientFactory (unit)', (): void => {
             environment: Environment.Sandbox,
         },
         logger: console,
+        logContext: {
+            someKey: 'someValue',
+            merchantId: 'unknown',
+        },
     };
 
     describe('#create', (): void => {
@@ -67,6 +71,9 @@ describe('SquareClientFactory (unit)', (): void => {
                 },
                 configuration: DEFAULT_CONFIGURATION,
                 logger: undefined,
+                logContext: {
+                    merchantId: 'unknown',
+                },
             });
         });
 


### PR DESCRIPTION
This is a 🐛 bug fix.

The production environment automatically uses a minified version of the code from the Square library. Because of this, it is impossible to get the real name of the class instance (via instance.`constructor.name`)