### PR TITLE
fix: converts the first character of apiName to upper case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/square-connect-plus",
     "description": "Extends the official Square Node.js SDK library with additional functionality",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "author": "Coroliov Oleg",
     "license": "MIT",
     "private": false,
@@ -79,8 +79,8 @@
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.5",
         "@types/lodash.camelcase": "^4.3.6",
-        "@types/lodash.capitalize": "^4.2.7",
         "@types/lodash.snakecase": "^4.1.6",
+        "@types/lodash.upperfirst": "^4.3.7",
         "@types/mocha": "^9.1.0",
         "@types/node": "^16.11.24",
         "@types/sinon": "^10.0.11",
@@ -116,6 +116,6 @@
         "uuid": "^8.3.2"
     },
     "dependencies": {
-        "lodash.capitalize": "^4.2.1"
+        "lodash.upperfirst": "^4.3.1"
     }
 }

--- a/src/client/SquareClient.ts
+++ b/src/client/SquareClient.ts
@@ -1,4 +1,4 @@
-import capitalize from 'lodash.capitalize';
+import upperFirst from 'lodash.upperfirst';
 import type {
     ApiResponse,
     Error as SquareError,
@@ -265,7 +265,7 @@ export class SquareClient {
                         ...logContext,
                         retries,
                         maxRetries,
-                        apiName: capitalize(apiName),
+                        apiName: upperFirst(apiName),
                         apiMethodName,
                         startedAt,
                         finishedAt,
@@ -286,7 +286,7 @@ export class SquareClient {
                 const execTime = finishedAt - startedAt;
                 logger.info(`Square api request: ${apiMethodName} executed in ${execTime}ms`, {
                     ...logContext,
-                    apiName: capitalize(apiName),
+                    apiName: upperFirst(apiName),
                     apiMethodName,
                     startedAt,
                     finishedAt,


### PR DESCRIPTION

This is a 🐛 bug fix.
fix: converts the first character of `apiName` to upper case